### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npm install @p233/stylelint-config-scss --save-dev
 ```
 
 ```
-yarn add @p233/stylelint-config-scss -dev
+yarn add @p233/stylelint-config-scss --dev
 ```
 
 ## Usage


### PR DESCRIPTION
Added missing hyphen — the option to add a dev package in Yarn is `--dev`, not `-dev` (which ignores the `-d` and `-e` and just prints the Yarn version 😁 )